### PR TITLE
Remove repeated code blocks in ffi-cdecl.lua and fix Makefile dependencies

### DIFF
--- a/ffi-cdecl/Makefile
+++ b/ffi-cdecl/Makefile
@@ -45,12 +45,12 @@ clean:
 	$(MAKE) -C gcc-lua clean
 
 test: test-ffi-cdecl test-gcc-lua test-gcc-lua-cdecl
-test-ffi-cdecl:
+test-ffi-cdecl: $(PLUGINLIB)
 	./ffi-cdecl $(CROSSCC) test/util.c > test/util.lua
 	./ffi-cdecl $(CROSSCXX) test/sample.cpp > test/sample.lua
 test-gcc-lua: $(PLUGINLIB)
 	$(MAKE) CC=$(CROSSCC) CXX=$(CROSSCXX) -C gcc-lua test
-test-gcc-lua-cdecl:
+test-gcc-lua-cdecl: $(PLUGINLIB)
 	$(MAKE) CC=$(CROSSCC) CXX=$(CROSSCXX) -C gcc-lua-cdecl test
 
 # For detecting the toolchain GCC_VERSION, we preprocess the

--- a/ffi-cdecl/ffi-cdecl.lua
+++ b/ffi-cdecl/ffi-cdecl.lua
@@ -29,25 +29,9 @@ gcc.register_callback(gcc.PLUGIN_FINISH_UNIT, function()
         if node == decl then return name end
       end) .. ";")
     end
-    local name = orig:match("^cdecl_struct__(.+)")
-    if name then
-      -- get pointee type
-      local type = nodes[i]:type():type()
-      -- output type with API name
-      print(cdecl.declare(type, function(node)
-        if node == type then return name end
-      end) .. ";")
-    end
-    local name = orig:match("^cdecl_enum__(.+)")
-    if name then
-      -- get pointee type
-      local type = nodes[i]:type():type()
-      -- output type with API name
-      print(cdecl.declare(type, function(node)
-        if node == type then return name end
-      end) .. ";")
-    end
-    local name = orig:match("^cdecl_union__(.+)")
+    local name = orig:match("^cdecl_struct__(.+)") or
+        orig:match("^cdecl_enum__(.+)") or
+        orig:match("^cdecl_union__(.+)")
     if name then
       -- get pointee type
       local type = nodes[i]:type():type()


### PR DESCRIPTION
Make struct, enum and union declarations use the same block of code
