### PR TITLE
lua_xgettext.py: reintroduce multiline strings

### DIFF
--- a/gettext/lua_xgettext.py
+++ b/gettext/lua_xgettext.py
@@ -4,6 +4,8 @@
 ##########################################################################
 # This script is taken from wideland project:
 # http://bazaar.launchpad.net/~widelands-dev/widelands/trunk/files/head:/utils/
+# Upstream project switched to real gettext. Last relevant revision at:
+# http://bazaar.launchpad.net/~widelands-dev/widelands/trunk/view/6845/utils/lua_xgettext.py
 ##########################################################################
 
 
@@ -29,9 +31,9 @@ class Lua_GetText(object):
     _SIMPLE_STRING = re.compile(
         r'''_\(        #parenthese must follow _
         (?P<all_text>(
-            (?P<quote>["'])  #  opening string mark?
+            ((?P<quote>["'])|(?P<doublep>\[\[))  #  opening string mark?
             (?P<text>.*?(?<!\\))
-            (?(quote)(?P=quote))\s*
+            (?(quote)(?P=quote)|\]\])\s*
         )+)\)
         ''', re.M | re.DOTALL | re.VERBOSE
     )
@@ -93,8 +95,9 @@ class Lua_GetText(object):
             else:
                 s += 'msgid ""\n'
                 lines = string.split('\n')
-                s += ''.join('"%s\\n"\n' % l for l in lines[:-1])
-                s += '"%s"\n' % lines[-1]
+                s += '"'
+                s += ''.join('%s\\n' % l for l in lines[:-1])
+                s += '%s"\n' % lines[-1]
             s += 'msgstr ""\n\n'
 
         return s


### PR DESCRIPTION
This change is inspired by a quickstart guide idea I was playing around with, but I think this change is useful regardless whether that idea ever makes it in.

The quickstart idea is based on https://github.com/koreader/koreader/issues/2632#issuecomment-290985621 The concept is simply to have a variable like the following. It's a lot easier to read and edit than an enormous `\n`-infested string, and therefore less prone to errors, which applies to most multiline strings in the code:

```lua
local _ = require("gettext")

return _([[# Quickstart Guide

Swipe down on top of the screen to activate the menu. You can click outside
the menu or swipe up on the menu to discard it.

Click the gear icon to change your language.]])
```

Of course that particular example would only be useful if coupled with language selection on first start.

This is my (destructive) Markdown proof of concept button in the filemanager, btw:

```lua
                {
                    text = _("Convert"),
                    enabled = lfs.attributes(file, "mode") == "file"
                        and util.getFileNameSuffix(file) == "md" and true or false,
                    callback = function()
                        local MD = require("frontend/md")
                        local f = io.open(file, "rb")
                        local content = f:read("*all")
                        f:close()
                        --logger.dbg(content)
                        local md_options = {
                            prependHead = "<!DOCTYPE html><html>",
                            appendTail = "</html>",
                            tag = "body",
                            insertHead = string.format("<head><title>%s</title></head>", file),
                        }
                        local html, err = MD(content, md_options)
                        logger.dbg("THE ERROR", err)
                        if html then
                            f = io.open(file..".html", "w")
                            f:write(html)
                            f:close()
                        end
                        UIManager:close(self.file_dialog)
                        self:refreshPath()
                    end,
                },
```

It errors out on various random documents I tried, for example because links have underscores in them (it thinks `http://bla_bla` is an unclosed `_emphasis_`) so I'm not entirely sure about the exact utility value, but it's quite cool when it works. But that aside.