### PR TITLE
[fix] Eat newline after [[ like Lua

### DIFF
--- a/gettext/lua_xgettext.py
+++ b/gettext/lua_xgettext.py
@@ -32,7 +32,7 @@ class Lua_GetText(object):
     _SIMPLE_STRING = re.compile(
         r'''(_|gettext)\(        #parenthese must follow _
         (?P<all_text>(
-            ((?P<quote>["'])|(?P<doublep>\[\[))  #  opening string mark?
+            ((?P<quote>["'])|(?P<doublep>\[\[(\n)?))  #  opening string mark? ignore newline directly after [[ like Lua
             (?P<text>.*?(?<!\\))
             (?(quote)(?P=quote)|\]\])\s*
         )+)\)


### PR DESCRIPTION
Otherwise we would get mismatches because a Lua string between `[[]]`
regards the first newline in a block like this as decorative:

```lua
[[
I am a string with no newline at the start.
]]
```

Fixes https://github.com/koreader/koreader/issues/4522, fixes https://github.com/koreader/koreader/issues/4085.