### PR TITLE
nightswatcher: don't try to remove signature

### DIFF
--- a/nightswatcher/Dockerfile
+++ b/nightswatcher/Dockerfile
@@ -4,7 +4,7 @@ RUN add-apt-repository -y ppa:openjdk-r/ppa
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         python-wheel python-setuptools build-essential python-dev python-pip \
-        unzip zip zipalign zsync openjdk-8-jdk \
+        unzip zipalign zsync openjdk-8-jdk \
     && apt-get remove -y openjdk-7-jre-headless \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/nightswatcher/Makefile
+++ b/nightswatcher/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.4.16
+VERSION=0.4.17
 
 all: build
 

--- a/nightswatcher/nightswatcher.py
+++ b/nightswatcher/nightswatcher.py
@@ -74,8 +74,6 @@ def run_cmd(cmd):
 def sign_apk(apk_path):
     # TODO: move to apk signature scheme v2 for faster install on
     # android N
-    logger.info('Removing existing debug signature from %s...', apk_path)
-    run_cmd(['zip', '-d', apk_path, 'META-INF/*'])
 
     logger.info('Signing %s...', apk_path)
     re = gevent.subprocess.check_output(


### PR DESCRIPTION
In just using release APKs there's no need for that.

See https://github.com/koreader/koreader/pull/4532