### PR TITLE
[Android] nightswatcher: switch to uber-apk-signer for v1 & v2 signing 

### DIFF
--- a/nightswatcher/Dockerfile
+++ b/nightswatcher/Dockerfile
@@ -12,4 +12,6 @@ COPY ./requirements.txt /requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt && rm -rf /tmp/* /var/tmp/*
 COPY ./nightswatcher.py /nightswatcher.py
 
+RUN curl -L https://github.com/patrickfav/uber-apk-signer/releases/download/v1.0.0/uber-apk-signer-1.0.0.jar >/uber-apk-signer.jar
+
 CMD ["/usr/local/bin/gunicorn", "--access-logfile", "-", "-b", "0.0.0.0:9742", "-w", "1", "-k", "gevent", "nightswatcher:api"]

--- a/nightswatcher/Makefile
+++ b/nightswatcher/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.4.17
+VERSION=0.4.18
 
 all: build
 

--- a/nightswatcher/nightswatcher.py
+++ b/nightswatcher/nightswatcher.py
@@ -80,7 +80,7 @@ def sign_apk(apk_path):
          '--ksAlias', APK_SIGN_KEY_ALIAS,
          '--ksKeyPass', APK_SIGN_KEY_PASS,
          '--ksPass', APK_SIGN_STORE_PASS,
-         '--apks', apk_path, 'koreader_release',
+         '--apks', apk_path,
          '--overwrite',
          '--verbose'])
     logger.info('Output from uber-apk-signer:\n%s', re)

--- a/nightswatcher/nightswatcher.py
+++ b/nightswatcher/nightswatcher.py
@@ -27,6 +27,7 @@ build_fetch_queue = queue.Queue()
 
 
 APK_SIGN_KEY_PASS = os.environ['APK_SIGN_KEY_PASS']
+APK_SIGN_KEY_ALIAS = os.environ['APK_SIGN_KEY_ALIAS']
 APK_SIGN_STORE_PASS = os.environ['APK_SIGN_STORE_PASS']
 GITLAB_TOKEN = os.environ['GITLAB_WEBHOOK_TOKEN']
 GITLAB_TRIGGER_TOKEN = os.environ['GITLAB_TRIGGER_TOKEN']
@@ -72,23 +73,17 @@ def run_cmd(cmd):
 
 
 def sign_apk(apk_path):
-    # TODO: move to apk signature scheme v2 for faster install on
-    # android N
-
     logger.info('Signing %s...', apk_path)
     re = gevent.subprocess.check_output(
-        ['jarsigner', '-verbose', '-sigalg', 'SHA1withRSA',
-         '-digestalg', 'SHA1', '-tsa', 'http://timestamp.digicert.com',
-         '-keystore', APK_SIGN_KEY_STORE_PATH,
-         '-keypass', APK_SIGN_KEY_PASS,
-         '-storepass', APK_SIGN_STORE_PASS,
-         apk_path, 'koreader_release'])
-    logger.info('Output from jarsigner:\n%s', re)
-
-    aligned_apk_path = apk_path + '_apligned'
-    run_cmd(['zipalign', '-v', '4', apk_path, aligned_apk_path])
-
-    run_cmd(['mv', '-f', aligned_apk_path, apk_path])
+        ['java', '-jar', 'uber-apk-signer.jar',
+         '--ks', APK_SIGN_KEY_STORE_PATH,
+         '--ksAlias', APK_SIGN_KEY_ALIAS,
+         '--ksKeyPass', APK_SIGN_KEY_PASS,
+         '--ksPass', APK_SIGN_STORE_PASS,
+         '--apks', apk_path, 'koreader_release',
+         '--overwrite',
+         '--verbose'])
+    logger.info('Output from uber-apk-signer:\n%s', re)
 
 
 def get_artifact_metadata(artifact_zip):


### PR DESCRIPTION
This allows for faster installation on Android 7 and higher.