### PR TITLE
nightswatcher: support friendly names by making arch match optional

### DIFF
--- a/nightswatcher/Makefile
+++ b/nightswatcher/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.6.3
+VERSION=0.6.4
 
 all: build
 

--- a/nightswatcher/nightswatcher.py
+++ b/nightswatcher/nightswatcher.py
@@ -45,7 +45,7 @@ STABLE_BUILD_DIR = BUILD_DIR + 'stable'
 artifact_re = re.compile(
     ('.*/koreader-'
      '(?P<platform>[a-z0-9\-]+)-'
-     '(?P<arch>arm|i686|x86_64)-.*-'
+     '(?P<arch>arm|x86|i686|x86_64)-?.*-'
      '(?P<version>v[0-9]{4}\.[0-9]{2}(?:\.[0-9]{1,2})?(?:-(?P<commit_number>[0-9]+))?(?:-g(?P<commit_hash>[0-9a-z]{7})_(?P<commit_date>[0-9]{4}-[0-9]{2}-[0-9]{2})?)?)'
      '\.(?P<ftype>[A-Za-z]+).*'))
 


### PR DESCRIPTION
See <https://github.com/koreader/koreader/pull/5268>.