### PR TITLE
nightswatcher: update and prune

### DIFF
--- a/nightswatcher/Dockerfile
+++ b/nightswatcher/Dockerfile
@@ -1,14 +1,14 @@
-FROM phusion/baseimage:0.10.2
+FROM phusion/baseimage:0.11
 
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install --no-install-recommends -y \
-        python-wheel python-setuptools build-essential python-dev python-pip \
-        unzip zipalign zsync openjdk-8-jdk \
+        python3-wheel python3-setuptools build-essential python3-dev python3-pip \
+        unzip zipalign zsync openjdk-8-jre-headless \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY ./requirements.txt /requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt && rm -rf /tmp/* /var/tmp/*
+RUN pip3 install --no-cache-dir -r requirements.txt && rm -rf /tmp/* /var/tmp/*
 COPY ./nightswatcher.py /nightswatcher.py
 
 RUN curl -L https://github.com/patrickfav/uber-apk-signer/releases/download/v1.0.0/uber-apk-signer-1.0.0.jar >/uber-apk-signer.jar

--- a/nightswatcher/Makefile
+++ b/nightswatcher/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.6.4
+VERSION=0.7.0
 
 all: build
 
@@ -9,6 +9,11 @@ build:
 run:
 	docker run --name nightswatcher -d koreader/nightswatcher:$(VERSION)
 
+shell:
+	docker run --detach-keys "ctrl-q,ctrl-q" --rm -t -i koreader/nightswatcher:$(VERSION) bash -l
+
 push:
 	docker push koreader/nightswatcher:$(VERSION)
 	docker push koreader/nightswatcher:latest
+
+.PHONY: all build run push shell

--- a/nightswatcher/requirements.txt
+++ b/nightswatcher/requirements.txt
@@ -1,6 +1,6 @@
-falcon==1.0.0
+falcon==2.0.0
 ujson==1.35
-gunicorn==19.6.0
-gevent==1.1.2
+gunicorn==19.9.0
+gevent==1.4.0
 streql==3.0.2
 requests


### PR DESCRIPTION
Ubuntu 18.04, Python 3, and updated requirements.

Also use `openjdk-8-jre-headless` instead of `openjdk-8-jdk` which I'd stupidly used because I would on desktop.
The problem with `openjdk-8-jdk` is less that it *supports* audio and video, which would waste only some space, but more that it pulls in the likes of pulse, mesa and all their dependencies. The resulting image is some 200 MB smaller.