### PR TITLE
Nightswatcher: increase allowed size of hash

### DIFF
--- a/nightswatcher/Dockerfile
+++ b/nightswatcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.11
+FROM phusion/baseimage:focal-1.0.0
 
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -11,6 +11,6 @@ COPY ./requirements.txt /requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt && rm -rf /tmp/* /var/tmp/*
 COPY ./nightswatcher.py /nightswatcher.py
 
-RUN curl -L https://github.com/patrickfav/uber-apk-signer/releases/download/v1.1.0/uber-apk-signer-1.1.0.jar >/uber-apk-signer.jar
+RUN curl -L https://github.com/patrickfav/uber-apk-signer/releases/download/v1.2.1/uber-apk-signer-1.2.1.jar >/uber-apk-signer.jar
 
 CMD ["/usr/local/bin/gunicorn", "--access-logfile", "-", "-b", "0.0.0.0:9742", "-w", "1", "-k", "gevent", "nightswatcher:api"]

--- a/nightswatcher/Makefile
+++ b/nightswatcher/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.7.3
+VERSION=0.8.0
 
 all: build
 

--- a/nightswatcher/nightswatcher.py
+++ b/nightswatcher/nightswatcher.py
@@ -108,7 +108,6 @@ def get_artifact_metadata(artifact_zip):
         commit_number = m.group("commit_number")
         ftype = m.group("ftype")
         artifact[ftype] = os.path.basename(f.strip())
-        break
 
     zf.close()
     return platform, version, commit_number, artifact

--- a/nightswatcher/nightswatcher.py
+++ b/nightswatcher/nightswatcher.py
@@ -46,7 +46,7 @@ artifact_re = re.compile(
     ('.*/koreader-'
      '(?P<platform>[a-z0-9\-]+)-'
      '(?:(?P<arch>arm|x86|i686|x86_64)-?.*-)?'
-     '(?P<version>v[0-9]{4}\.[0-9]{2}(?:\.[0-9]{1,2})?(?:-(?P<commit_number>[0-9]+))?(?:-g(?P<commit_hash>[0-9a-z]{7})_(?P<commit_date>[0-9]{4}-[0-9]{2}-[0-9]{2})?)?)'
+     '(?P<version>v[0-9]{4}\.[0-9]{2}(?:\.[0-9]{1,2})?(?:-(?P<commit_number>[0-9]+))?(?:-g(?P<commit_hash>[0-9a-z]{7,12})_(?P<commit_date>[0-9]{4}-[0-9]{2}-[0-9]{2})?)?)'
      '\.(?P<ftype>[A-Za-z]+).*'))
 
 def trigger_build():
@@ -99,6 +99,7 @@ def get_artifact_metadata(artifact_zip):
     commit_number = None
     artifact = {}
     for f in zf.namelist():
+        logger.info('Checking file in zip %s', f)
         m = artifact_re.match(f)
         if not m:
             continue
@@ -107,6 +108,7 @@ def get_artifact_metadata(artifact_zip):
         commit_number = m.group("commit_number")
         ftype = m.group("ftype")
         artifact[ftype] = os.path.basename(f.strip())
+        break
 
     zf.close()
     return platform, version, commit_number, artifact

--- a/nightswatcher/requirements.txt
+++ b/nightswatcher/requirements.txt
@@ -1,6 +1,6 @@
-falcon==2.0.0
-ujson==1.35
-gunicorn==20.0.4
-gevent==1.4.0
+falcon==3.0.1
+ujson==4.0.2
+gunicorn==20.1.0
+gevent==21.1.2
 streql==3.0.2
 requests


### PR DESCRIPTION
Git adds more characters to disambiguate if necessary, and apparently we've graduated from 7 to 8. See https://github.com/git/git/commit/e6c587c733b4634030b353f4024794b08bc86892
Also see https://github.com/koreader/koreader/issues/7805

Includes a few random updates as well that shouldn't have any noticeable effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-misc/40)
<!-- Reviewable:end -->
