### PR TITLE
nightswatcher: use hmac.compare_digest()

### DIFF
--- a/nightswatcher/Makefile
+++ b/nightswatcher/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.9.0-20.04
+VERSION=0.9.1-20.04
 
 all: build
 

--- a/nightswatcher/nightswatcher.py
+++ b/nightswatcher/nightswatcher.py
@@ -6,6 +6,7 @@ from gevent import queue
 monkey.patch_all()  # NOQA
 import gevent
 import falcon
+import hmac
 import ujson
 import os
 import logging
@@ -258,7 +259,7 @@ def fetch_build_worker():
 class PipeLine():
     def on_post(self, req, resp):
         token = req.headers.get('X-GITLAB-TOKEN')
-        if not token or not token == GITLAB_TOKEN:
+        if not token or not hmac.compare_digest(token, GITLAB_TOKEN):
             raise falcon.HTTPBadRequest('Yoyo', '')
 
         try:


### PR DESCRIPTION
> Return a == b. This function uses an approach designed to prevent timing analysis by avoiding content-based short circuiting behaviour, making it appropriate for cryptography. a and b must both be of the same type: either str (ASCII only, as e.g. returned by HMAC.hexdigest()), or a bytes-like object.

Fixes #51.